### PR TITLE
Fix MapBuilder when it contains a list of lists

### DIFF
--- a/lib/event_serializer/helpers/map_builder.ex
+++ b/lib/event_serializer/helpers/map_builder.ex
@@ -23,11 +23,14 @@ defmodule EventSerializer.Helpers.MapBuilder do
   """
   def to_map(list) when is_list(list) and length(list) > 0 do
     case list |> List.first() do
-      {_, _} ->
+      {_, _} = t when is_tuple(t) ->
         Enum.reduce(list, %{}, fn tuple, acc ->
           {key, value} = tuple
           Map.put(acc, key, to_map(value))
         end)
+
+      l when is_list(l) ->
+        Enum.map(list, &to_map/1)
 
       _ ->
         list

--- a/test/event_serializer/helpers/map_builder_test.exs
+++ b/test/event_serializer/helpers/map_builder_test.exs
@@ -1,0 +1,30 @@
+defmodule EventSerializer.Helpers.MapBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias EventSerializer.Helpers.MapBuilder
+
+  describe "to_map/1" do
+    test "converts the list of tuple formats to an Elixir map" do
+      payload = [
+        {"a",
+         [
+           {"b", "c"}
+         ]},
+        {"list_of_lists",
+         [
+           [{"a", "b"}, {"c", "d"}],
+           [{"a", "b"}, {"c", "d"}]
+         ]}
+      ]
+
+      expected = %{
+        "a" => %{
+          "b" => "c"
+        },
+        "list_of_lists" => [%{"a" => "b", "c" => "d"}, %{"a" => "b", "c" => "d"}]
+      }
+
+      assert MapBuilder.to_map(payload) == expected
+    end
+  end
+end


### PR DESCRIPTION
When the decoded result of a Kafka message contains a list of lists, MapBuilder returns a list of tuples instead of a list of records.

Example:

```
[
  {"a",
   [
     {"b", "c"},
   ]},
  {"list_of_lists",
   [
     [{"a", "b"}, {"c", "d"}],
     [{"a", "b"}, {"c", "d"}],
   ]}
  ]
```

Returns

```
%{
  "a" => %{
    "b" => "c",
  },
  "list_of_lists" => [[{"a", "b"}, {"c", "d"}], [{"a", "b"}, {"c", "d"}]]
}
```

This PR fixes the issue so that `lists_of_lists` is properly parsed.