### PR TITLE
Update to use 1.2.0 verson of Tesla

### DIFF
--- a/lib/event_serializer/schema_registry_adapter.ex
+++ b/lib/event_serializer/schema_registry_adapter.ex
@@ -6,8 +6,7 @@ defmodule EventSerializer.SchemaRegistryAdapter do
 
   alias EventSerializer.Config
 
-  plug(Tesla.Middleware.Headers, %{"Content-Type" => "application/json"})
-  plug Tesla.Middleware.Tuples
+  plug(Tesla.Middleware.Headers, [{"Content-Type", "application/json"}])
   plug(Tesla.Middleware.JSON)
   plug(Tesla.Middleware.Logger)
 
@@ -27,9 +26,11 @@ defmodule EventSerializer.SchemaRegistryAdapter do
 
   defp extract_response({:error, reason}, _attribute), do: {:error, reason}
   defp extract_response(nil, _attribute), do: {:error, "nothing returned"}
+
   defp extract_response(%{"error_code" => _error_code, "message" => message}, _attribute) do
     {:error, message}
   end
+
   defp extract_response(%{"id" => _id, "schema" => _schema} = map, attribute) do
     map |> Map.fetch!(attribute)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,14 +4,14 @@ defmodule EventSerializer.MixProject do
   def project do
     [
       app: :event_serializer,
-      version: "0.1.5",
+      version: "1.0.0",
       elixir: "~> 1.4",
-      elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
       description: description(),
-      package: package(),
+      package: package()
     ]
   end
 
@@ -32,10 +32,10 @@ defmodule EventSerializer.MixProject do
     [
       {:avlizer, "~> 0.2.0"},
       {:poison, "~> 3.1.0"},
-      {:tesla, "~> 0.10.0"},
+      {:tesla, "~> 1.2.0"},
       {:env_config, "~> 0.1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false},
+      {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false}
     ]
   end
 
@@ -44,7 +44,7 @@ defmodule EventSerializer.MixProject do
   defp package do
     [
       files: ["lib", "mix.exs"],
-      maintainers: ["Luiz Varela", "Ian Vaughan"],
+      maintainers: ["Luiz Varela", "Ian Vaughan", "Danny Hawkins"],
       licenses: ["MIT"],
       links: %{repository: "https://github.com/quiqupltd/event_serializer"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"avlizer": {:hex, :avlizer, "0.2.0", "f14c3ef3295840f52452a18c456fb326a37700bd1f9710b0db7fc10eade5faf5", [:rebar3], [{:erlavro, "2.5.0", [hex: :erlavro, repo: "hexpm", optional: false]}], "hexpm"},
+%{
+  "avlizer": {:hex, :avlizer, "0.2.0", "f14c3ef3295840f52452a18c456fb326a37700bd1f9710b0db7fc10eade5faf5", [:rebar3], [{:erlavro, "2.5.0", [hex: :erlavro, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "confex": {:hex, :confex, "3.3.1", "8febaf751bf293a16a1ed2cbd258459cdcc7ca53cfa61d3f83d49dd276a992b4", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
@@ -9,4 +10,5 @@
   "jsone": {:hex, :jsone, "1.4.3", "6d5f802136249e64f9d4997043b13355c6eac314217dc3b19bf3677e351a0641", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "tesla": {:hex, :tesla, "0.10.0", "e588c7e7f1c0866c81eeed5c38f02a4a94d6309eede336c1e6ca08b0a95abd3f", [:mix], [{:exjsx, ">= 0.1.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.2", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"}}
+  "tesla": {:hex, :tesla, "1.2.0", "9e2469c1bcdb0cc8fe5fd3e9208432f3fee8e439a44f639d8ce72bcccd6f3566", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+}

--- a/test/event_serializer/schema_registry_adapter_test.exs
+++ b/test/event_serializer/schema_registry_adapter_test.exs
@@ -18,16 +18,11 @@ defmodule EventSerializer.SchemaRegistryAdapterTest do
       schema_name: schema_name
     } do
       Tesla.Mock.mock(fn %{method: :get, url: ^url} ->
-        raise %Tesla.Error{message: "adapter error: :econnrefused", reason: :econnrefused}
+        {:error, :econnrefused}
       end)
 
-      response = {
-        :error,
-        %Tesla.Error{
-          message: "adapter error: :econnrefused",
-          reason: :econnrefused
-        }
-      }
+      response = {:error, :econnrefused}
+
       assert Subject.schema_for(schema_name) == response
     end
 


### PR DESCRIPTION
So that we can take advantage of `Tesla.Middleware.Logger, log_level: &log_level/1` in a downstream project I am updating here, changing the major version as there are breaking changes in Tesla