### PR TITLE
Changes topic into a list of topics to preload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: elixir
 matrix:
   include:
     - otp_release: 19.2
-      elixir: 1.4.5
-    - otp_release: 19.2
       elixir: 1.5.1
     - otp_release: 20.0
       elixir: 1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for event_serializer
 
+## 2.0.0
+
+- Allow for multiple topics in configuration
+
+
 ## 1.0.0
 
 - Update to user Testa 1.2.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @luizvarela @ianvaughan @danhawkins
+* @luizvarela @ianvaughan @danhawkins @thau

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ config :avlizer,
 
 config :event_serializer,
   schema_registry_url: "http://localhost:8081",
-  topic_name: "com.example.topic.name",
+  topic_names: ["com.example.topic.name"],
   enabled: true
 ```
 We need those two `schema_registry_url` because the `avlizer` requires it.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This lib is responsible to encode and decode events from Kafka. it also includes
 ```elixir
 def deps do
   [
-    {:event_serializer, "~> 0.1.5"}
+    {:event_serializer, "~> 2.0.0"}
   ]
 end
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,7 @@ config :avlizer,
 # {:system, :string, "AVLIZER_CONFLUENT_SCHEMAREGISTRY_URL", "http://localhost:8081"}
 config :event_serializer,
   schema_registry_url: "http://localhost:8081",
-  topic_name: "topic_name",
+  topic_names: ["topic_name"],
   enabled: true,
   schema_registry: EventSerializer.SchemaRegistryCache,
   avlizer_confluent: :avlizer_confluent,

--- a/lib/event_serializer/config.ex
+++ b/lib/event_serializer/config.ex
@@ -3,12 +3,12 @@ defmodule EventSerializer.Config do
   Helpers for getting config
   """
 
-  def topic_name do
-    :event_serializer |> EnvConfig.get(:topic_name) |> not_nil_topic_name
+  def topic_names do
+    :event_serializer |> EnvConfig.get(:topic_names) |> not_nil_topic_names
   end
 
-  defp not_nil_topic_name(nil), do: ""
-  defp not_nil_topic_name(topic_name), do: topic_name
+  defp not_nil_topic_names(nil), do: []
+  defp not_nil_topic_names(topic_names), do: topic_names
 
   def schema_registry_url do
     EnvConfig.get(:event_serializer, :schema_registry_url)
@@ -23,7 +23,11 @@ defmodule EventSerializer.Config do
   end
 
   def schema_registry_adapter do
-    EnvConfig.get(:event_serializer, :schema_registry_adapter, EventSerializer.SchemaRegistryAdapter)
+    EnvConfig.get(
+      :event_serializer,
+      :schema_registry_adapter,
+      EventSerializer.SchemaRegistryAdapter
+    )
   end
 
   def schema_registry do

--- a/lib/event_serializer/schema_registry_cache.ex
+++ b/lib/event_serializer/schema_registry_cache.ex
@@ -95,34 +95,41 @@ defmodule EventSerializer.SchemaRegistryCache do
     ]
   """
   def fetch_schemas do
-    schema_name_id = key_schema_name() |> fetch_id() |> make_encoder()
-    schema_value_id = value_schema_name() |> fetch_id() |> make_encoder()
-
-    format_response(schema_name_id, schema_value_id)
+    topics()
+    |> Enum.flat_map(&fetch_schema/1)
   end
 
   def fetch_id(name), do: name |> schema_registry_adapter().schema_id_for()
 
-  def key_schema_name, do: topic() <> "-key"
-  def value_schema_name, do: topic() <> "-value"
+  def key_schema_name(topic), do: topic <> "-key"
+  def value_schema_name(topic), do: topic <> "-value"
 
-  defp format_response(_schema_name_id, nil), do: []
-  defp format_response(nil, _schema_value_id), do: []
-  defp format_response(schema_name_id, schema_value_id) do
+  defp fetch_schema(topic) do
+    schema_name_id = key_schema_name(topic) |> fetch_id() |> make_encoder()
+    schema_value_id = value_schema_name(topic) |> fetch_id() |> make_encoder()
+
+    format_response(topic, schema_name_id, schema_value_id)
+  end
+
+  defp format_response(_topic, _schema_name_id, nil), do: []
+  defp format_response(_topic, nil, _schema_value_id), do: []
+
+  defp format_response(topic, schema_name_id, schema_value_id) do
     [
-      %{id: schema_name_id, name: key_schema_name()},
-      %{id: schema_value_id, name: value_schema_name()}
+      %{id: schema_name_id, name: key_schema_name(topic)},
+      %{id: schema_value_id, name: value_schema_name(topic)}
     ]
   end
 
   defp make_encoder({:error, _reason}), do: nil
+
   defp make_encoder(value) do
     value |> avlizer_confluent().make_encoder()
     value
   end
 
   # Config from env
-  defp topic, do: Config.topic_name()
-  defp avlizer_confluent, do: Config.avlizer_confluent
-  defp schema_registry_adapter, do: Config.schema_registry_adapter
+  defp topics, do: Config.topic_names()
+  defp avlizer_confluent, do: Config.avlizer_confluent()
+  defp schema_registry_adapter, do: Config.schema_registry_adapter()
 end

--- a/lib/event_serializer/schema_registry_cache.ex
+++ b/lib/event_serializer/schema_registry_cache.ex
@@ -105,8 +105,8 @@ defmodule EventSerializer.SchemaRegistryCache do
   def value_schema_name(topic), do: topic <> "-value"
 
   defp fetch_schema(topic) do
-    schema_name_id = key_schema_name(topic) |> fetch_id() |> make_encoder()
-    schema_value_id = value_schema_name(topic) |> fetch_id() |> make_encoder()
+    schema_name_id = topic |> key_schema_name() |> fetch_id() |> make_encoder()
+    schema_value_id = topic |> value_schema_name() |> fetch_id() |> make_encoder()
 
     format_response(topic, schema_name_id, schema_value_id)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EventSerializer.MixProject do
     [
       app: :event_serializer,
       version: "2.0.0",
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EventSerializer.MixProject do
   def project do
     [
       app: :event_serializer,
-      version: "1.0.0",
+      version: "2.0.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -45,7 +45,7 @@ defmodule EventSerializer.MixProject do
     [
       name: "event_serializer",
       files: ["lib", "mix.exs", "CHANGELOG*", "LICENSE*", "README*"],
-      maintainers: ["@luizvarela", "@ianvaughan", "@danhawkins"],
+      maintainers: ["@luizvarela", "@ianvaughan", "@danhawkins", "@thau"],
       licenses: ["MIT"],
       source_url: "https://github.com/quiqupltd/event_serializer",
       links: %{"GitHub" => "https://github.com/quiqupltd/event_serializer"}

--- a/test/event_serializer/schema_registry_cache_test.exs
+++ b/test/event_serializer/schema_registry_cache_test.exs
@@ -4,37 +4,40 @@ defmodule EventSerializer.SchemaRegistryCacheTest do
   alias EventSerializer.SchemaRegistryCache, as: Subject
 
   setup do
-    topic_name = Application.get_env :event_serializer, :topic_name
-    Application.put_env :event_serializer, :topic_name, "known-topic"
+    topic_names = Application.get_env(:event_serializer, :topic_names)
+    Application.put_env(:event_serializer, :topic_names, ["known-topic-1", "known-topic-2"])
 
-    on_exit fn ->
-      Application.put_env :event_serializer, :topic_name, topic_name
-    end
+    on_exit(fn ->
+      Application.put_env(:event_serializer, :topic_names, topic_names)
+    end)
 
-    Subject.start_link
+    Subject.start_link()
 
     :ok
   end
 
   describe "fetch_schemas/0" do
     test "it returns an empty array when the Schema Registry does not respond" do
-      Application.put_env :event_serializer, :topic_name, "unknown-topic"
+      Application.put_env(:event_serializer, :topic_names, ["unknown-topic"])
 
-      assert [] == Subject.fetch_schemas
+      assert [] == Subject.fetch_schemas()
     end
 
     test "it returns correct map when the Schema Registry does respond" do
       expected_result = [
-        %{id: 1, name: "known-topic-key"},
-        %{id: 1, name: "known-topic-value"}
+        %{id: 1, name: "known-topic-1-key"},
+        %{id: 1, name: "known-topic-1-value"},
+        %{id: 2, name: "known-topic-2-key"},
+        %{id: 2, name: "known-topic-2-value"}
       ]
-      assert Subject.fetch_schemas == expected_result
+
+      assert Subject.fetch_schemas() == expected_result
     end
   end
 
   describe "fetch/1" do
     test "when the schema is found it returns the schema id" do
-      assert Subject.fetch("known-topic-key") == 1
+      assert Subject.fetch("known-topic-1-key") == 1
     end
 
     test "when the schema is not found it returns the schema id" do

--- a/test/support/mocks/avlizer_confluent.ex
+++ b/test/support/mocks/avlizer_confluent.ex
@@ -1,9 +1,10 @@
 defmodule EventSerializer.TestSupport.Mocks.AvlizerConfluentMock do
   # matches when the schema is found and returned via SchemaRegistryMock
   def make_encoder(_known_schema_id = 1), do: "encoder"
+  def make_encoder(_known_schema_id = 2), do: "encoder"
   # :avlizer_confluent.encode(encoder, [{"id", 123}]) # => <<246, 1>>
   def encode("encoder", "valid_payload"), do: <<246, 1>>
-  def encode("encoder", "bad_payload"), do: raise ErlangError
+  def encode("encoder", "bad_payload"), do: raise(ErlangError)
 
   # matches raw kafka payload when the encoded byte has version 1 schema
   # eg <<0, 0, 0, 0, 1, ...
@@ -12,5 +13,5 @@ defmodule EventSerializer.TestSupport.Mocks.AvlizerConfluentMock do
   # default the matching decoder to return a known message
   def decode("decoder1", <<246, 1>>), do: <<246, 1>>
   def decode("decoder2", payload), do: payload
-  def decode("decoder1", <<246, 1, 2>>), do: raise MatchError
+  def decode("decoder1", <<246, 1, 2>>), do: raise(MatchError)
 end

--- a/test/support/mocks/schema_registry_adapter.ex
+++ b/test/support/mocks/schema_registry_adapter.ex
@@ -1,5 +1,7 @@
 defmodule EventSerializer.TestSupport.Mocks.SchemaRegistryAdapterMock do
-  def schema_id_for("known-topic-key"), do: 1
-  def schema_id_for("known-topic-value"), do: 1
+  def schema_id_for("known-topic-1-key"), do: 1
+  def schema_id_for("known-topic-1-value"), do: 1
+  def schema_id_for("known-topic-2-key"), do: 2
+  def schema_id_for("known-topic-2-value"), do: 2
   def schema_id_for(unknown_topic), do: {:error, unknown_topic}
 end


### PR DESCRIPTION
Our current implementation only allows one topic's schema to be preloaded and used, but we need to be able to push different events in different topics. This MR converts it into a list so that we can preload multiple topics's schemas.