### PR TITLE
Fix so that nulls are converted to Elixir nils instead of :null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for event_serializer
 
+## 2.0.1
+
+- Fix decoding nulls into proper nils
+
 ## 2.0.0
 
 - Allow for multiple topics in configuration

--- a/lib/event_serializer/helpers/map_builder.ex
+++ b/lib/event_serializer/helpers/map_builder.ex
@@ -42,5 +42,6 @@ defmodule EventSerializer.Helpers.MapBuilder do
     Enum.into([{key, to_map(value)}], %{})
   end
 
+  def to_map(:null), do: nil
   def to_map(value), do: value
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EventSerializer.MixProject do
   def project do
     [
       app: :event_serializer,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/event_serializer/helpers/map_builder_test.exs
+++ b/test/event_serializer/helpers/map_builder_test.exs
@@ -26,5 +26,11 @@ defmodule EventSerializer.Helpers.MapBuilderTest do
 
       assert MapBuilder.to_map(payload) == expected
     end
+
+    test "null atoms are converted to nils" do
+      payload = [{"a", :null}]
+
+      assert MapBuilder.to_map(payload) == %{"a" => nil}
+    end
   end
 end


### PR DESCRIPTION
When decoding something that contains nulls, erlavro will return `:null`. This needs to be converted to `nil` in EventSerializer properly.